### PR TITLE
Handle existing PreUser on contact verification

### DIFF
--- a/controllers/registroController.js
+++ b/controllers/registroController.js
@@ -38,15 +38,18 @@ export const verificarContacto = async (req, res, next) => {
 
   // 4 resultados
   if (!mongoUser && !firebaseUser) {
-    // Nuevo usuario
+    // Nuevo usuario. Si ya existe un PreUser con este email, reutilizarlo
     try {
-      const preUser = await PreUser.create({
-        name,
-        lastName,
-        email,
-        phoneNumber,
-        jobTitle
-      });
+      let preUser = await PreUser.findOne({ email }).exec();
+      if (!preUser) {
+        preUser = await PreUser.create({
+          name,
+          lastName,
+          email,
+          phoneNumber,
+          jobTitle
+        });
+      }
       return res.json({ status: 'new', preUserId: preUser._id });
     } catch (err) {
       console.error('Error guardando PreUser:', err);

--- a/tests/registro.test.js
+++ b/tests/registro.test.js
@@ -26,6 +26,7 @@ describe('Registro', () => {
     findUserInMongo.mockResolvedValue({ user: null, error: null });
     findUserInFirebase.mockResolvedValue({ user: null, error: null });
     PreUser.create.mockResolvedValue({ _id: 'pre1' });
+    PreUser.findOne.mockReturnValue({ exec: () => Promise.resolve(null) });
 
     const res = await request(app)
       .post('/registro/contacto')
@@ -40,6 +41,26 @@ describe('Registro', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ status: 'new', preUserId: 'pre1' });
     expect(PreUser.create).toHaveBeenCalled();
+  });
+
+  test('verificarContacto reutiliza PreUser existente', async () => {
+    findUserInMongo.mockResolvedValue({ user: null, error: null });
+    findUserInFirebase.mockResolvedValue({ user: null, error: null });
+    PreUser.findOne.mockReturnValue({ exec: () => Promise.resolve({ _id: 'pre1' }) });
+
+    const res = await request(app)
+      .post('/registro/contacto')
+      .send({
+        name: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        phoneNumber: '123',
+        jobTitle: 'Dev'
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'new', preUserId: 'pre1' });
+    expect(PreUser.create).not.toHaveBeenCalled();
   });
 
   test('iniciarPago retorna client_secret', async () => {


### PR DESCRIPTION
## Resumen
- reutilizar un documento PreUser existente en lugar de generar un error
- verificar el contacto cuando el PreUser ya existe

## Pruebas
- `npm test`
