### PR TITLE
Refactor PreUser creation and extend contact tests

### DIFF
--- a/controllers/registroController.js
+++ b/controllers/registroController.js
@@ -15,8 +15,9 @@ export const verificarContacto = async (req, res, next) => {
   }
 
   // Buscar pre-registro existente antes de consultar las bases de datos
+  let preUser;
   try {
-    const preUser = await PreUser.findOne({ email }).exec();
+    preUser = await PreUser.findOne({ email }).exec();
     if (preUser) {
       return res.json({ status: 'new', preUserId: preUser._id });
     }
@@ -53,19 +54,16 @@ export const verificarContacto = async (req, res, next) => {
 
   // 4 resultados
   if (!mongoUser && !firebaseUser) {
-    // Nuevo usuario. Si ya existe un PreUser con este email, reutilizarlo
+    // Nuevo usuario: crear pre-registro
     try {
-      let preUser = await PreUser.findOne({ email }).exec();
-      if (!preUser) {
-        preUser = await PreUser.create({
-          name,
-          lastName,
-          email,
-          phoneNumber,
-          jobTitle
-        });
-      }
-      return res.json({ status: 'new', preUserId: preUser._id });
+      const newPreUser = await PreUser.create({
+        name,
+        lastName,
+        email,
+        phoneNumber,
+        jobTitle
+      });
+      return res.json({ status: 'new', preUserId: newPreUser._id });
     } catch (err) {
       console.error('Error guardando PreUser:', err);
       return res.status(500).json({

--- a/tests/registro.test.js
+++ b/tests/registro.test.js
@@ -63,6 +63,26 @@ describe('Registro', () => {
     expect(PreUser.create).not.toHaveBeenCalled();
   });
 
+  test('verificarContacto no crea PreUser si usuario existe en User', async () => {
+    PreUser.findOne.mockReturnValue({ exec: () => Promise.resolve(null) });
+    findUserInMongo.mockResolvedValue({ user: { _id: 'u1' }, error: null });
+    findUserInFirebase.mockResolvedValue({ user: null, error: null });
+
+    const res = await request(app)
+      .post('/registro/contacto')
+      .send({
+        name: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        phoneNumber: '123',
+        jobTitle: 'Dev'
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ status: 'pendingAuth', user: { _id: 'u1' } });
+    expect(PreUser.create).not.toHaveBeenCalled();
+  });
+
   test('iniciarPago retorna client_secret', async () => {
     const preUser = {
       _id: 'pre1',


### PR DESCRIPTION
## Summary
- create PreUser only after verifying email does not exist
- keep PreUser.create behind try/catch
- test contact route when a PreUser already exists
- test contact route when user exists in Mongo

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687879ec0e3c83238c79e4bf25be3e67