### PR TITLE
Modularizar consulta y creación de PreUser

### DIFF
--- a/services/preUserService.js
+++ b/services/preUserService.js
@@ -1,0 +1,29 @@
+import PreUser from '../models/PreUser.js';
+
+/**
+ * Busca un PreUser por email.
+ * @param {string} email
+ * @returns {Promise<{ preUser: object|null, error: Error|null }>}
+ */
+export async function findPreUserByEmail(email) {
+  try {
+    const preUser = await PreUser.findOne({ email }).exec();
+    return { preUser, error: null };
+  } catch (error) {
+    return { preUser: null, error };
+  }
+}
+
+/**
+ * Crea un nuevo PreUser.
+ * @param {{ name:string, lastName:string, email:string, phoneNumber?:string, jobTitle?:string }} data
+ * @returns {Promise<{ preUser: object|null, error: Error|null }>}
+ */
+export async function createPreUser(data) {
+  try {
+    const preUser = await PreUser.create(data);
+    return { preUser, error: null };
+  } catch (error) {
+    return { preUser: null, error };
+  }
+}


### PR DESCRIPTION
## Resumen
- nueva capa de servicio `preUserService` para buscar y crear registros `PreUser`
- se refactorizó `verificarContacto` para utilizar estas funciones y un manejador de errores reutilizable
- pruebas actualizadas para usar los nuevos mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791aad62588323895ba781c5a98849