### PR TITLE
Add env var validation for Stripe

### DIFF
--- a/config/stripe.js
+++ b/config/stripe.js
@@ -2,7 +2,15 @@
 
 import Stripe from 'stripe';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+// Validar que la clave secreta de Stripe esté configurada
+const { STRIPE_SECRET_KEY } = process.env;
+if (!STRIPE_SECRET_KEY) {
+  const msg = 'Falta STRIPE_SECRET_KEY en las variables de entorno';
+  console.error(msg);
+  throw new Error(msg);
+}
+
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
   apiVersion: '2022-11-15'
 });
 export default stripe;

--- a/services/paymentService.js
+++ b/services/paymentService.js
@@ -1,5 +1,13 @@
 import stripe from '../config/stripe.js';
 
+// Validar que los IDs de precios estén configurados
+const { PRICE_ID_MONTHLY, PRICE_ID_YEARLY } = process.env;
+if (!PRICE_ID_MONTHLY || !PRICE_ID_YEARLY) {
+  const msg = 'Faltan PRICE_ID_MONTHLY o PRICE_ID_YEARLY en las variables de entorno';
+  console.error(msg);
+  throw new Error(msg);
+}
+
 /**
  * Crea un intent de suscripción gestionando el cliente de Stripe.
  * @param {{ name:string, lastName:string, email:string, phoneNumber?:string, jobTitle?:string }} contact


### PR DESCRIPTION
## Summary
- validate Stripe env variables before usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687dbca8005083238cd109321fef7669